### PR TITLE
Handle profile click action

### DIFF
--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -3,7 +3,7 @@ import * as FileSystem from 'expo-file-system';
 import { uploadString } from 'firebase/storage';
 import { View, Text, FlatList, ActivityIndicator, StyleSheet, Image, TouchableOpacity, SafeAreaView, TextInput } from 'react-native';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
-import { collection, query, orderBy, onSnapshot, getDoc, doc as firestoreDoc, setDoc } from 'firebase/firestore';
+import { collection, query, orderBy, onSnapshot, getDoc, doc as firestoreDoc, setDoc, where } from 'firebase/firestore';
 import { auth, db } from '../../firebase';
 import { signOut } from 'firebase/auth';
 import * as ImagePicker from 'expo-image-picker';


### PR DESCRIPTION
Fixes crash on profile screen by importing missing `where` function.

---
<a href="https://cursor.com/background-agent?bcId=bc-64512e91-5a14-43ac-89b5-dfe2b6498049">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64512e91-5a14-43ac-89b5-dfe2b6498049">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

